### PR TITLE
test: add multi-WO field test cases and update policy docs

### DIFF
--- a/docs/policies/prefer-write-only-resource-attributes.md
+++ b/docs/policies/prefer-write-only-resource-attributes.md
@@ -8,35 +8,26 @@
 
 This policy checks if resources with write-only attribute options are using them.
 
-This policy checks for resources that have write-only attribute options available but are not using them. Write-only attributes are a security feature that allows sensitive values to be set in a resource without storing them in the Terraform state file.
+Write-only attributes are a security feature that allows sensitive values to be set in a resource without storing them in the Terraform state file. The policy compares the resources in your Terraform configuration against a list of known resources that have write-only attribute options and fails if any of those resources are configured without using at least one write-only attribute.
 
-The policy compares the resources in your Terraform configuration against a list of resources that have write-only attribute options available. For each resource that has a write-only option, the policy checks if that option is being used.
-
-The policy will fail if it finds resources in your configuration that have write-only attribute options available but are not using them.
+Some resources expose more than one write-only attribute (for example, `tfe_notification_configuration` has both `token_wo` and `url_wo`). The policy passes as long as at least one write-only attribute is present in the resource configuration.
 
 Note that if the Terraform version detected in your configuration is less than 1.11, the check will pass automatically. This is because write-only attributes were introduced in Terraform 1.11.
 
-
 This policy is implemented in the [prefer-write-only-resource-attributes.sentinel](https://github.com/drewmullen/policy-library-ephemerality/blob/main/prefer-write-only-resource-attributes.sentinel) file.
 
+## Test Cases
+
+| Test File | Config | Expected |
+|-----------|--------|----------|
+| `fail.hcl` | `aws_ssm_parameter` using `value` (non-WO) | Fail |
+| `success.hcl` | `aws_ssm_parameter` using `value_wo` | Pass |
+| `success-version-too-low.hcl` | `aws_ssm_parameter` using `value`, Terraform < 1.11 | Pass |
+| `fail-multi-wo.hcl` | `tfe_notification_configuration` using neither `token_wo` nor `url_wo` | Fail |
+| `success-multi-wo-partial.hcl` | `tfe_notification_configuration` using `token_wo` only | Pass |
+| `success-multi-wo-all.hcl` | `tfe_notification_configuration` using both `token_wo` and `url_wo` | Pass |
+
 ## Policy Results (Pass)
-
-```bash
-  trace:
-    prefer-write-only-resource-attributes.sentinel:27:1 - Rule "main"
-      Description:
-        A new write only attribute available for managed resources used,
-        please use those instead
-
-      Value:
-        false
-
-    prefer-write-only-resource-attributes.sentinel:21:1 - Rule "rule_against_resources_with_wo_not_set"
-      Value:
-        false
-```
-
-## Policy Results (Fail)
 
 ```bash
 trace:
@@ -51,4 +42,21 @@ trace:
   prefer-write-only-resource-attributes.sentinel:21:1 - Rule "rule_against_resources_with_wo_not_set"
     Value:
       true
+```
+
+## Policy Results (Fail)
+
+```bash
+trace:
+  prefer-write-only-resource-attributes.sentinel:27:1 - Rule "main"
+    Description:
+      A new write only attribute available for managed resources used,
+      please use those instead
+
+    Value:
+      false
+
+  prefer-write-only-resource-attributes.sentinel:21:1 - Rule "rule_against_resources_with_wo_not_set"
+    Value:
+      false
 ```

--- a/test/prefer-write-only-resource-attributes/fail-multi-wo.hcl
+++ b/test/prefer-write-only-resource-attributes/fail-multi-wo.hcl
@@ -1,0 +1,22 @@
+import "static" "ephemeral-data" {
+    source = "../../data/ephemerality.json"
+    format = "json"
+}
+
+mock "tfconfig/v2" {
+    module {
+        source = "./testdata/tfconfig-multi-wo-fail.sentinel"
+    }
+}
+
+mock "tfplan/v2" {
+    module {
+        source = "./testdata/tfplan-above.sentinel"
+    }
+}
+
+test {
+    rules  = {
+        main = false
+    }
+}

--- a/test/prefer-write-only-resource-attributes/success-multi-wo-all.hcl
+++ b/test/prefer-write-only-resource-attributes/success-multi-wo-all.hcl
@@ -1,0 +1,22 @@
+import "static" "ephemeral-data" {
+    source = "../../data/ephemerality.json"
+    format = "json"
+}
+
+mock "tfconfig/v2" {
+    module {
+        source = "./testdata/tfconfig-multi-wo-success-all.sentinel"
+    }
+}
+
+mock "tfplan/v2" {
+    module {
+        source = "./testdata/tfplan-above.sentinel"
+    }
+}
+
+test {
+    rules  = {
+        main = true
+    }
+}

--- a/test/prefer-write-only-resource-attributes/success-multi-wo-partial.hcl
+++ b/test/prefer-write-only-resource-attributes/success-multi-wo-partial.hcl
@@ -1,0 +1,22 @@
+import "static" "ephemeral-data" {
+    source = "../../data/ephemerality.json"
+    format = "json"
+}
+
+mock "tfconfig/v2" {
+    module {
+        source = "./testdata/tfconfig-multi-wo-success-partial.sentinel"
+    }
+}
+
+mock "tfplan/v2" {
+    module {
+        source = "./testdata/tfplan-above.sentinel"
+    }
+}
+
+test {
+    rules  = {
+        main = true
+    }
+}

--- a/test/prefer-write-only-resource-attributes/testdata/tfconfig-multi-wo-fail.sentinel
+++ b/test/prefer-write-only-resource-attributes/testdata/tfconfig-multi-wo-fail.sentinel
@@ -1,0 +1,45 @@
+import "strings"
+
+providers = {
+	"tfe": {
+		"alias":               "",
+		"config":              {},
+		"full_name":           "registry.terraform.io/hashicorp/tfe",
+		"module_address":      "",
+		"name":                "tfe",
+		"provider_config_key": "tfe",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"tfe_notification_configuration.test": {
+		"address": "tfe_notification_configuration.test",
+		"config": {
+			"destination_type": {
+				"constant_value": "generic",
+			},
+			"name": {
+				"constant_value": "test",
+			},
+			"token": {
+				"constant_value": "super-secret-token",
+			},
+			"url": {
+				"constant_value": "https://example.com/webhook",
+			},
+			"workspace_id": {
+				"constant_value": "ws-abc123",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "test",
+		"provider_config_key": "tfe",
+		"provisioners":        [],
+		"type":                "tfe_notification_configuration",
+	},
+}

--- a/test/prefer-write-only-resource-attributes/testdata/tfconfig-multi-wo-success-all.sentinel
+++ b/test/prefer-write-only-resource-attributes/testdata/tfconfig-multi-wo-success-all.sentinel
@@ -1,0 +1,46 @@
+import "strings"
+
+providers = {
+	"tfe": {
+		"alias":               "",
+		"config":              {},
+		"full_name":           "registry.terraform.io/hashicorp/tfe",
+		"module_address":      "",
+		"name":                "tfe",
+		"provider_config_key": "tfe",
+		"version_constraint":  "",
+	},
+}
+
+// Both token_wo and url_wo are set.
+resources = {
+	"tfe_notification_configuration.test": {
+		"address": "tfe_notification_configuration.test",
+		"config": {
+			"destination_type": {
+				"constant_value": "generic",
+			},
+			"name": {
+				"constant_value": "test",
+			},
+			"token_wo": {
+				"constant_value": "super-secret-token",
+			},
+			"url_wo": {
+				"constant_value": "https://example.com/webhook",
+			},
+			"workspace_id": {
+				"constant_value": "ws-abc123",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "test",
+		"provider_config_key": "tfe",
+		"provisioners":        [],
+		"type":                "tfe_notification_configuration",
+	},
+}

--- a/test/prefer-write-only-resource-attributes/testdata/tfconfig-multi-wo-success-partial.sentinel
+++ b/test/prefer-write-only-resource-attributes/testdata/tfconfig-multi-wo-success-partial.sentinel
@@ -1,0 +1,46 @@
+import "strings"
+
+providers = {
+	"tfe": {
+		"alias":               "",
+		"config":              {},
+		"full_name":           "registry.terraform.io/hashicorp/tfe",
+		"module_address":      "",
+		"name":                "tfe",
+		"provider_config_key": "tfe",
+		"version_constraint":  "",
+	},
+}
+
+// Only token_wo is set; url_wo is not. Policy should pass because at least one WO field is used.
+resources = {
+	"tfe_notification_configuration.test": {
+		"address": "tfe_notification_configuration.test",
+		"config": {
+			"destination_type": {
+				"constant_value": "generic",
+			},
+			"name": {
+				"constant_value": "test",
+			},
+			"token_wo": {
+				"constant_value": "super-secret-token",
+			},
+			"url": {
+				"constant_value": "https://example.com/webhook",
+			},
+			"workspace_id": {
+				"constant_value": "ws-abc123",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "test",
+		"provider_config_key": "tfe",
+		"provisioners":        [],
+		"type":                "tfe_notification_configuration",
+	},
+}


### PR DESCRIPTION
Tests cover tfe_notification_configuration (token_wo + url_wo):
- fail when neither WO field is set
- pass when one WO field is set (token_wo only)
- pass when both WO fields are set

Also fixes swapped Pass/Fail trace examples in the policy doc and documents the multi-WO behavior and full test case table.