### PR TITLE
feat: add local report module and improve policy error messages

### DIFF
--- a/modules/report/report.sentinel
+++ b/modules/report/report.sentinel
@@ -1,0 +1,74 @@
+// report module — generates structured policy output
+//
+// Usage:
+//   summary = {
+//     "policy_name": "my-policy",
+//     "violations": [
+//       {"address": "aws_s3_bucket.foo", "module_address": "", "message": "reason"},
+//     ],
+//   }
+//   print(generate_policy_report(summary))
+
+green  = "\033[32m"
+red    = "\033[31m"
+reset  = "\033[0m"
+
+arrow      = "→"
+down_arrow = "↳"
+check      = "✓"
+cross      = "✗"
+pipe       = "|"
+
+root_module = "root"
+
+generate_policy_report = func(summary) {
+	if length(summary.violations) == 0 {
+		return _success(summary.policy_name)
+	} else {
+		return _failure(summary)
+	}
+}
+
+_success = func(policy_name) {
+	r  = green + arrow + " " + arrow + " Overall Result: true" + reset + "\n"
+	r += "\n"
+	r += check + " All resources passed the policy check for " + policy_name + ".\n"
+	r += "\n"
+	r += check + " Found 0 resource violations"
+	return r
+}
+
+_failure = func(summary) {
+	r  = red + arrow + " " + arrow + " Overall Result: false" + reset + "\n"
+	r += "\n"
+	r += cross + " Not all resources passed the policy check for " + summary.policy_name + ".\n"
+	r += "\n"
+	r += "Found " + string(length(summary.violations)) + " resource violation(s):\n"
+
+	module_map = _group_by_module(summary.violations)
+	for keys(module_map) as mod {
+		r += "\n"
+		r += arrow + " Module: " + mod + "\n"
+		for module_map[mod] as v {
+			r += "  " + down_arrow + " Resource Address: " + v.address + "\n"
+			r += "    " + pipe + " " + cross + " failed\n"
+			r += "    " + pipe + " " + v.message + "\n"
+		}
+	}
+	return r
+}
+
+_group_by_module = func(violations) {
+	m = {}
+	for violations as v {
+		mod = v.module_address
+		if mod is "" {
+			mod = root_module
+		}
+		if mod not in keys(m) {
+			m[mod] = []
+		}
+		append(m[mod], v)
+	}
+	return m
+}

--- a/prefer-ephemeral-creates.sentinel
+++ b/prefer-ephemeral-creates.sentinel
@@ -2,6 +2,7 @@ import "tfconfig/v2" as tfconfig
 import "tfplan/v2" as tfplan
 import "strings"
 import "ephemeral-data" as rd
+import "report" as report
 
 param filtered_resources default []
 
@@ -17,10 +18,20 @@ secret_bearing_resources = filter tfconfig.resources as _, rc {
 	rc.type in filtered_resources
 }
 
-if length(secret_bearing_resources) != 0 {
-	print()
-	print("Details: Resources that store secret values in state should use the write-only argument.")
+violations = map secret_bearing_resources as addr, rc {
+	{
+		"address":        addr,
+		"module_address": rc.module_address,
+		"message":        "resource stores secret values in state; use an ephemeral resource instead",
+	}
 }
+
+summary = {
+	"policy_name": "prefer-ephemeral-creates",
+	"violations":  violations,
+}
+
+print(report.generate_policy_report(summary))
 
 rule_against_secret_bearing_resources = rule {
 	length(secret_bearing_resources) == 0

--- a/prefer-ephemeral-retrieves.sentinel
+++ b/prefer-ephemeral-retrieves.sentinel
@@ -2,6 +2,7 @@ import "tfconfig/v2" as tfconfig
 import "tfplan/v2" as tfplan
 import "strings"
 import "ephemeral-data" as rd
+import "report" as report
 
 VERSION = strings.split(tfplan.terraform_version, ".")
 MAJOR = VERSION[0]
@@ -11,10 +12,20 @@ secret_bearing_datasources = filter tfconfig.resources as _, rc {
 	rc.type in rd.ephemeral and rc.mode == "data"
 }
 
-if length(secret_bearing_datasources) != 0 {
-	print()
-	print("Details: Data sources that store secret values in state are blocked.")
+violations = map secret_bearing_datasources as addr, rc {
+	{
+		"address":        addr,
+		"module_address": rc.module_address,
+		"message":        "data source stores secret values in state; use an ephemeral resource instead",
+	}
 }
+
+summary = {
+	"policy_name": "prefer-ephemeral-retrieves",
+	"violations":  violations,
+}
+
+print(report.generate_policy_report(summary))
 
 rule_against_secret_bearing_datasources = rule {
 	length(secret_bearing_datasources) == 0

--- a/prefer-write-only-resource-attributes.sentinel
+++ b/prefer-write-only-resource-attributes.sentinel
@@ -2,6 +2,7 @@ import "tfconfig/v2" as tfconfig
 import "tfplan/v2" as tfplan
 import "ephemeral-data" as rd
 import "strings"
+import "report" as report
 
 VERSION = strings.split(tfplan.terraform_version, ".")
 MAJOR = VERSION[0]
@@ -13,10 +14,20 @@ resources_with_wo_available = filter tfconfig.resources as _, rc {
 		all rd.write_only[rc.type] as wo_field { wo_field not in keys(rc.config) }
 }
 
-if length(resources_with_wo_available) != 0 {
-	print()
-	print("Details: resources that have a write-only attribute option are preferred.")
+violations = map resources_with_wo_available as addr, rc {
+	{
+		"address":        addr,
+		"module_address": rc.module_address,
+		"message":        "write-only attribute(s) available but not configured (available: " + strings.join(rd.write_only[rc.type], ", ") + ")",
+	}
 }
+
+summary = {
+	"policy_name": "prefer-write-only-resource-attributes",
+	"violations":  violations,
+}
+
+print(report.generate_policy_report(summary))
 
 rule_against_resources_with_wo_not_set = rule {
 	length(resources_with_wo_available) == 0 or

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -3,6 +3,10 @@ import "static" "ephemeral-data" {
     format = "json"
 }
 
+import "module" "report" {
+    source = "./modules/report/report.sentinel"
+}
+
 policy "prefer-ephemeral-retrieves" {
     source = "./prefer-ephemeral-retrieves.sentinel"
     enforcement_level = "advisory"

--- a/test/prefer-ephemeral-creates/fail.hcl
+++ b/test/prefer-ephemeral-creates/fail.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "../../data/ephemerality.json"
     format = "json"

--- a/test/prefer-ephemeral-creates/success-version-too-low.hcl
+++ b/test/prefer-ephemeral-creates/success-version-too-low.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "../../data/ephemerality.json"
     format = "json"

--- a/test/prefer-ephemeral-creates/success.hcl
+++ b/test/prefer-ephemeral-creates/success.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "../../data/ephemerality.json"
     format = "json"

--- a/test/prefer-ephemeral-retrieves/fail.hcl
+++ b/test/prefer-ephemeral-retrieves/fail.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "https://raw.githubusercontent.com/drewmullen/policy-library-ephemerality/refs/heads/main/data/ephemerality.json"
     format = "json"

--- a/test/prefer-ephemeral-retrieves/success-version-too-low.hcl
+++ b/test/prefer-ephemeral-retrieves/success-version-too-low.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "https://raw.githubusercontent.com/drewmullen/policy-library-ephemerality/refs/heads/main/data/ephemerality.json"
     format = "json"

--- a/test/prefer-ephemeral-retrieves/success.hcl
+++ b/test/prefer-ephemeral-retrieves/success.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "https://raw.githubusercontent.com/drewmullen/policy-library-ephemerality/refs/heads/main/data/ephemerality.json"
     format = "json"

--- a/test/prefer-write-only-resource-attributes/fail-multi-wo.hcl
+++ b/test/prefer-write-only-resource-attributes/fail-multi-wo.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "../../data/ephemerality.json"
     format = "json"

--- a/test/prefer-write-only-resource-attributes/fail.hcl
+++ b/test/prefer-write-only-resource-attributes/fail.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "https://raw.githubusercontent.com/drewmullen/policy-library-ephemerality/refs/heads/main/data/ephemerality.json"
     format = "json"

--- a/test/prefer-write-only-resource-attributes/success-multi-wo-all.hcl
+++ b/test/prefer-write-only-resource-attributes/success-multi-wo-all.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "../../data/ephemerality.json"
     format = "json"

--- a/test/prefer-write-only-resource-attributes/success-multi-wo-partial.hcl
+++ b/test/prefer-write-only-resource-attributes/success-multi-wo-partial.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "../../data/ephemerality.json"
     format = "json"

--- a/test/prefer-write-only-resource-attributes/success-version-too-low.hcl
+++ b/test/prefer-write-only-resource-attributes/success-version-too-low.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "https://raw.githubusercontent.com/drewmullen/policy-library-ephemerality/refs/heads/main/data/ephemerality.json"
     format = "json"

--- a/test/prefer-write-only-resource-attributes/success.hcl
+++ b/test/prefer-write-only-resource-attributes/success.hcl
@@ -1,3 +1,7 @@
+import "module" "report" {
+    source = "../../modules/report/report.sentinel"
+}
+
 import "static" "ephemeral-data" {
     source = "https://raw.githubusercontent.com/drewmullen/policy-library-ephemerality/refs/heads/main/data/ephemerality.json"
     format = "json"


### PR DESCRIPTION
Closes #4

## Summary

- Adds `modules/report/report.sentinel` — a local structured reporting module with a single exported `generate_policy_report(summary)` function
- All three policies now print colored pass/fail output with resource addresses and specific violation messages instead of a single generic line
- The write-only policy includes which WO fields are available in each violation message
- Wires the module into `sentinel.hcl` and all 12 test HCL files

## Example output (fail)

```
→ → Overall Result: false

✗ Not all resources passed the policy check for prefer-write-only-resource-attributes.

Found 1 resource violation(s):

→ Module: root
  ↳ Resource Address: tfe_notification_configuration.test
    | ✗ failed
    | write-only attribute(s) available but not configured (available: token_wo, url_wo)
```

## Test plan

- [x] `sentinel test -run="prefer-write-only/.*multi-wo"` — all 3 pass